### PR TITLE
Add JetElite React frontend skeleton

### DIFF
--- a/jetelite/index.html
+++ b/jetelite/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JetElite</title>
+    <link rel="icon" href="/favicon.ico" />
+  </head>
+  <body class="bg-black text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/jetelite/package.json
+++ b/jetelite/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "jetelite",
+  "version": "1.0.0",
+  "description": "JetElite private jet booking app",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "vite": "^4.3.9"
+  },
+  "type": "module"
+}

--- a/jetelite/postcss.config.js
+++ b/jetelite/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/jetelite/src/App.jsx
+++ b/jetelite/src/App.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar.jsx';
+import Footer from './components/Footer.jsx';
+import HomePage from './pages/HomePage.jsx';
+import FleetPage from './pages/FleetPage.jsx';
+import JetDetailPage from './pages/JetDetailPage.jsx';
+import BookingPage from './pages/BookingPage.jsx';
+import AddOnsPage from './pages/AddOnsPage.jsx';
+import AboutPage from './pages/AboutPage.jsx';
+import SupportPage from './pages/SupportPage.jsx';
+import DashboardPage from './pages/DashboardPage.jsx';
+import BlogPage from './pages/BlogPage.jsx';
+import BlogDetailPage from './pages/BlogDetailPage.jsx';
+import LoginPage from './pages/LoginPage.jsx';
+import SignupPage from './pages/SignupPage.jsx';
+
+export default function App() {
+  return (
+    <div className="flex flex-col min-h-screen bg-black text-white">
+      <Navbar />
+      <div className="flex-grow pt-16">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/fleet" element={<FleetPage />} />
+          <Route path="/fleet/:id" element={<JetDetailPage />} />
+          <Route path="/booking" element={<BookingPage />} />
+          <Route path="/addons" element={<AddOnsPage />} />
+          <Route path="/about" element={<AboutPage />} />
+          <Route path="/support" element={<SupportPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/blog" element={<BlogPage />} />
+          <Route path="/blog/:id" element={<BlogDetailPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+        </Routes>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/jetelite/src/components/Footer.jsx
+++ b/jetelite/src/components/Footer.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+export default function Footer() {
+  return (
+    <footer className="bg-black text-center py-6 border-t border-gray-800">
+      <div className="space-x-4 mb-2">
+        <NavLink to="/terms" className="hover:text-gold">Terms</NavLink>
+        <NavLink to="/privacy" className="hover:text-gold">Privacy</NavLink>
+      </div>
+      <div className="space-x-4">
+        <a href="#" className="hover:text-gold">Twitter</a>
+        <a href="#" className="hover:text-gold">Instagram</a>
+        <a href="#" className="hover:text-gold">Facebook</a>
+      </div>
+      <p className="mt-2 text-sm text-gray-500">&copy; 2023 JetElite</p>
+    </footer>
+  );
+}

--- a/jetelite/src/components/JetCard.jsx
+++ b/jetelite/src/components/JetCard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function JetCard({ jet }) {
+  return (
+    <div className="bg-white text-black rounded shadow">
+      <img src={jet.image} alt={jet.model} className="w-full h-40 object-cover rounded-t" />
+      <div className="p-4">
+        <h3 className="font-semibold text-lg mb-2">{jet.model}</h3>
+        <p className="text-sm mb-1">Size: {jet.size}</p>
+        <p className="text-sm mb-1">Capacity: {jet.capacity}</p>
+        <p className="text-sm mb-2">Price: {jet.price}</p>
+        <Link to={`/fleet/${jet.id}`} className="text-gold hover:underline">View Details</Link>
+      </div>
+    </div>
+  );
+}

--- a/jetelite/src/components/Navbar.jsx
+++ b/jetelite/src/components/Navbar.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+export default function Navbar() {
+  return (
+    <nav className="fixed top-0 inset-x-0 z-50 bg-black bg-opacity-80 backdrop-blur">
+      <div className="max-w-7xl mx-auto px-4 py-3 flex justify-between items-center">
+        <NavLink to="/" className="text-lg font-bold text-gold">JetElite</NavLink>
+        <div className="space-x-4 hidden md:block">
+          <NavLink to="/fleet" className="hover:text-gold">Fleet</NavLink>
+          <NavLink to="/booking" className="hover:text-gold">Book</NavLink>
+          <NavLink to="/addons" className="hover:text-gold">Services</NavLink>
+          <NavLink to="/about" className="hover:text-gold">About</NavLink>
+          <NavLink to="/support" className="hover:text-gold">Support</NavLink>
+          <NavLink to="/blog" className="hover:text-gold">Blog</NavLink>
+          <NavLink to="/dashboard" className="hover:text-gold">Dashboard</NavLink>
+        </div>
+        <div className="space-x-2">
+          <NavLink to="/login" className="px-3 py-1 border border-gold rounded hover:bg-gold hover:text-black">Login</NavLink>
+          <NavLink to="/signup" className="px-3 py-1 bg-gold text-black rounded hover:bg-white">Sign Up</NavLink>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/jetelite/src/components/WizardSteps.jsx
+++ b/jetelite/src/components/WizardSteps.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function WizardSteps({ current }) {
+  const steps = ['Choose Jet', 'Select Date & Passengers', 'Choose Add-ons', 'Quote Preview'];
+  return (
+    <div className="flex justify-between mb-6">
+      {steps.map((label, idx) => (
+        <div key={idx} className="flex-1 text-center">
+          <div className={`w-8 h-8 mx-auto rounded-full flex items-center justify-center ${current === idx + 1 ? 'bg-gold text-black' : 'bg-gray-700'}`}>{idx + 1}</div>
+          <p className="text-xs mt-1">{label}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/jetelite/src/data/jets.js
+++ b/jetelite/src/data/jets.js
@@ -1,0 +1,44 @@
+const jets = [
+  {
+    id: 'light',
+    model: 'Light Jet',
+    image: 'https://unsplash.it/600/400?image=1050',
+    size: 'Small',
+    capacity: 4,
+    price: '$2,500/hr',
+    range: '1,500 mi',
+    description: 'Perfect for short trips with a small group.'
+  },
+  {
+    id: 'midsize',
+    model: 'Midsize Jet',
+    image: 'https://unsplash.it/600/400?image=1060',
+    size: 'Medium',
+    capacity: 7,
+    price: '$3,500/hr',
+    range: '2,500 mi',
+    description: 'Ideal balance of comfort and performance.'
+  },
+  {
+    id: 'super-midsize',
+    model: 'Super Midsize Jet',
+    image: 'https://unsplash.it/600/400?image=1070',
+    size: 'Medium-Large',
+    capacity: 9,
+    price: '$4,500/hr',
+    range: '3,500 mi',
+    description: 'Extra space and range for longer journeys.'
+  },
+  {
+    id: 'large',
+    model: 'Large Cabin Jet',
+    image: 'https://unsplash.it/600/400?image=1080',
+    size: 'Large',
+    capacity: 12,
+    price: '$6,000/hr',
+    range: '4,500 mi',
+    description: 'Ultimate luxury for long-distance travel.'
+  }
+];
+
+export default jets;

--- a/jetelite/src/index.css
+++ b/jetelite/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/jetelite/src/main.jsx
+++ b/jetelite/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/jetelite/src/pages/AboutPage.jsx
+++ b/jetelite/src/pages/AboutPage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function AboutPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h2 className="text-3xl font-bold mb-4 text-center">About JetElite</h2>
+      <p className="mb-4">JetElite is committed to delivering unparalleled private aviation experiences. Our mission is to provide luxury, safety, and convenience for discerning travelers.</p>
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="bg-gray-900 p-4 rounded">
+          <h3 className="text-xl mb-2">Our Mission</h3>
+          <p className="text-sm text-gray-400">To make private air travel accessible and effortless.</p>
+        </div>
+        <div className="bg-gray-900 p-4 rounded">
+          <h3 className="text-xl mb-2">Founders</h3>
+          <p className="text-sm text-gray-400">Jane Doe and John Smith, aviation enthusiasts with decades of experience.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/jetelite/src/pages/AddOnsPage.jsx
+++ b/jetelite/src/pages/AddOnsPage.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+
+export default function AddOnsPage() {
+  const [selected, setSelected] = useState({});
+  const services = [
+    { id: 'chauffeur', name: 'Chauffeur', img: 'https://unsplash.it/400/300?image=856' },
+    { id: 'catering', name: 'Catering', img: 'https://unsplash.it/400/300?image=1025' },
+    { id: 'concierge', name: 'Concierge', img: 'https://unsplash.it/400/300?image=823' },
+  ];
+
+  const toggle = (id) => setSelected(prev => ({ ...prev, [id]: !prev[id] }));
+
+  return (
+    <div className="max-w-6xl mx-auto p-4">
+      <h2 className="text-3xl font-bold mb-6 text-center">Add-On Services</h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        {services.map(s => (
+          <div key={s.id} className="bg-gray-900 rounded">
+            <img src={s.img} alt={s.name} className="w-full h-40 object-cover rounded-t" />
+            <div className="p-4 flex items-center justify-between">
+              <p>{s.name}</p>
+              <input type="checkbox" checked={!!selected[s.id]} onChange={() => toggle(s.id)} className="text-black" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/jetelite/src/pages/BlogDetailPage.jsx
+++ b/jetelite/src/pages/BlogDetailPage.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+const posts = {
+  1: 'The Future of Private Aviation - Full article coming soon...',
+  2: 'Top 5 Jet Destinations - Full article coming soon...',
+  3: 'Why Choose JetElite - Full article coming soon...',
+};
+
+export default function BlogDetailPage() {
+  const { id } = useParams();
+  const content = posts[id];
+
+  if (!content) return <p className="p-4">Article not found.</p>;
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <Link to="/blog" className="text-gold hover:underline">&larr; Back to Blog</Link>
+      <div className="mt-4 bg-gray-900 p-4 rounded">
+        <p>{content}</p>
+      </div>
+    </div>
+  );
+}

--- a/jetelite/src/pages/BlogPage.jsx
+++ b/jetelite/src/pages/BlogPage.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const posts = [
+  { id: 1, title: 'The Future of Private Aviation', date: '2023-01-10', preview: 'A look at upcoming trends in the industry.' },
+  { id: 2, title: 'Top 5 Jet Destinations', date: '2023-02-15', preview: 'Where to fly for luxury and relaxation.' },
+  { id: 3, title: 'Why Choose JetElite', date: '2023-03-20', preview: 'Discover the JetElite difference.' },
+];
+
+export default function BlogPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h2 className="text-3xl font-bold mb-6 text-center">Blog</h2>
+      <div className="space-y-4">
+        {posts.map(p => (
+          <div key={p.id} className="bg-gray-900 p-4 rounded">
+            <h3 className="text-xl mb-1"><Link to={`/blog/${p.id}`}>{p.title}</Link></h3>
+            <p className="text-sm text-gray-400 mb-1">{p.date}</p>
+            <p className="text-gray-300">{p.preview}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/jetelite/src/pages/BookingPage.jsx
+++ b/jetelite/src/pages/BookingPage.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import jets from '../data/jets.js';
+import WizardSteps from '../components/WizardSteps.jsx';
+
+export default function BookingPage() {
+  const [step, setStep] = useState(1);
+  const [selectedJet, setSelectedJet] = useState('');
+  const [date, setDate] = useState('');
+  const [passengers, setPassengers] = useState(1);
+  const [addons, setAddons] = useState({ chauffeur: false, catering: false, concierge: false });
+
+  const toggleAddon = (name) => {
+    setAddons(prev => ({ ...prev, [name]: !prev[name] }));
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <WizardSteps current={step} />
+      {step === 1 && (
+        <div>
+          <select value={selectedJet} onChange={e => setSelectedJet(e.target.value)} className="w-full p-2 mb-4 text-black">
+            <option value="">Select Jet</option>
+            {jets.map(j => (
+              <option key={j.id} value={j.id}>{j.model}</option>
+            ))}
+          </select>
+          <button className="px-4 py-2 bg-gold text-black rounded" onClick={() => setStep(2)}>Next</button>
+        </div>
+      )}
+      {step === 2 && (
+        <div className="space-y-4">
+          <input type="date" value={date} onChange={e => setDate(e.target.value)} className="w-full p-2 text-black" />
+          <input type="number" min="1" value={passengers} onChange={e => setPassengers(e.target.value)} className="w-full p-2 text-black" />
+          <div className="flex justify-between">
+            <button className="px-4 py-2 border border-gold rounded" onClick={() => setStep(1)}>Back</button>
+            <button className="px-4 py-2 bg-gold text-black rounded" onClick={() => setStep(3)}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 3 && (
+        <div className="space-y-2">
+          {['chauffeur','catering','concierge'].map(name => (
+            <label key={name} className="flex items-center space-x-2">
+              <input type="checkbox" checked={addons[name]} onChange={() => toggleAddon(name)} className="text-black" />
+              <span className="capitalize">{name}</span>
+            </label>
+          ))}
+          <div className="flex justify-between mt-4">
+            <button className="px-4 py-2 border border-gold rounded" onClick={() => setStep(2)}>Back</button>
+            <button className="px-4 py-2 bg-gold text-black rounded" onClick={() => setStep(4)}>Next</button>
+          </div>
+        </div>
+      )}
+      {step === 4 && (
+        <div className="space-y-4">
+          <p>Jet: {selectedJet}</p>
+          <p>Date: {date}</p>
+          <p>Passengers: {passengers}</p>
+          <p>Add-ons: {Object.entries(addons).filter(([k,v]) => v).map(([k]) => k).join(', ') || 'None'}</p>
+          <div className="flex justify-between">
+            <button className="px-4 py-2 border border-gold rounded" onClick={() => setStep(3)}>Back</button>
+            <button className="px-4 py-2 bg-gold text-black rounded" onClick={() => alert('Submitted!')}>Submit</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/jetelite/src/pages/DashboardPage.jsx
+++ b/jetelite/src/pages/DashboardPage.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function DashboardPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h2 className="text-3xl font-bold mb-4">Dashboard</h2>
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="bg-gray-900 p-4 rounded">
+          <h3 className="mb-2 font-semibold">Upcoming Trips</h3>
+          <ul className="text-sm text-gray-400 space-y-1">
+            <li>No upcoming trips.</li>
+          </ul>
+        </div>
+        <div className="bg-gray-900 p-4 rounded">
+          <h3 className="mb-2 font-semibold">Past Trips</h3>
+          <ul className="text-sm text-gray-400 space-y-1">
+            <li>None yet.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/jetelite/src/pages/FleetPage.jsx
+++ b/jetelite/src/pages/FleetPage.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import jets from '../data/jets.js';
+import JetCard from '../components/JetCard.jsx';
+
+export default function FleetPage() {
+  return (
+    <div className="max-w-6xl mx-auto p-4">
+      <h2 className="text-3xl font-bold mb-6 text-center">Our Fleet</h2>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        {jets.map(jet => (
+          <JetCard key={jet.id} jet={jet} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/jetelite/src/pages/HomePage.jsx
+++ b/jetelite/src/pages/HomePage.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function HomePage() {
+  return (
+    <div className="text-center pt-10 px-4">
+      <section className="my-12">
+        <h1 className="text-4xl md:text-6xl font-bold mb-4">Fly Private, Fly Elite</h1>
+        <p className="mb-6 text-gray-300">Seamless luxury jet charter at your fingertips.</p>
+        <div className="space-x-4">
+          <Link to="/fleet" className="px-5 py-2 bg-gold text-black rounded">View Fleet</Link>
+          <Link to="/booking" className="px-5 py-2 border border-gold rounded hover:bg-gold hover:text-black">Book Now</Link>
+        </div>
+      </section>
+      <section className="grid md:grid-cols-3 gap-6 max-w-5xl mx-auto mt-12">
+        <div className="p-4 bg-gray-900 rounded">
+          <h3 className="text-xl mb-2">Modern Fleet</h3>
+          <p className="text-sm text-gray-400">Choose from light to large cabin jets.</p>
+        </div>
+        <div className="p-4 bg-gray-900 rounded">
+          <h3 className="text-xl mb-2">Professional Chauffeur</h3>
+          <p className="text-sm text-gray-400">Door to door service at your destination.</p>
+        </div>
+        <div className="p-4 bg-gray-900 rounded">
+          <h3 className="text-xl mb-2">Gourmet Catering</h3>
+          <p className="text-sm text-gray-400">Indulge in curated meals during your flight.</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/jetelite/src/pages/JetDetailPage.jsx
+++ b/jetelite/src/pages/JetDetailPage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import jets from '../data/jets.js';
+
+export default function JetDetailPage() {
+  const { id } = useParams();
+  const jet = jets.find(j => j.id === id);
+
+  if (!jet) return <p className="p-4">Jet not found.</p>;
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <img src={jet.image} alt={jet.model} className="w-full h-60 object-cover rounded" />
+      <h2 className="text-3xl font-bold mt-4 mb-2">{jet.model}</h2>
+      <p className="mb-1">Size: {jet.size}</p>
+      <p className="mb-1">Capacity: {jet.capacity}</p>
+      <p className="mb-1">Range: {jet.range}</p>
+      <p className="mb-4">{jet.description}</p>
+      <Link to="/booking" className="px-5 py-2 bg-gold text-black rounded">Start Booking</Link>
+    </div>
+  );
+}

--- a/jetelite/src/pages/LoginPage.jsx
+++ b/jetelite/src/pages/LoginPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function LoginPage() {
+  return (
+    <div className="max-w-sm mx-auto p-4">
+      <h2 className="text-2xl font-bold mb-4 text-center">Login</h2>
+      <form className="space-y-4">
+        <input type="email" placeholder="Email" className="w-full p-2 text-black" />
+        <input type="password" placeholder="Password" className="w-full p-2 text-black" />
+        <button className="w-full px-4 py-2 bg-gold text-black rounded">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/jetelite/src/pages/SignupPage.jsx
+++ b/jetelite/src/pages/SignupPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function SignupPage() {
+  return (
+    <div className="max-w-sm mx-auto p-4">
+      <h2 className="text-2xl font-bold mb-4 text-center">Sign Up</h2>
+      <form className="space-y-4">
+        <input type="email" placeholder="Email" className="w-full p-2 text-black" />
+        <input type="password" placeholder="Password" className="w-full p-2 text-black" />
+        <button className="w-full px-4 py-2 bg-gold text-black rounded">Create Account</button>
+      </form>
+    </div>
+  );
+}

--- a/jetelite/src/pages/SupportPage.jsx
+++ b/jetelite/src/pages/SupportPage.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+export default function SupportPage() {
+  const [faqOpen, setFaqOpen] = useState(null);
+  const faqs = [
+    { q: 'How do I book a flight?', a: 'Use our booking page to get started.' },
+    { q: 'Can I cancel my booking?', a: 'Please contact support to cancel.' },
+    { q: 'Do you offer catering?', a: 'Yes, gourmet catering is available.' },
+  ];
+
+  const toggle = idx => setFaqOpen(faqOpen === idx ? null : idx);
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h2 className="text-3xl font-bold mb-6 text-center">Support</h2>
+      {faqs.map((f, idx) => (
+        <div key={idx} className="mb-2">
+          <button className="w-full text-left p-2 bg-gray-800" onClick={() => toggle(idx)}>{f.q}</button>
+          {faqOpen === idx && <div className="p-2 bg-gray-700">{f.a}</div>}
+        </div>
+      ))}
+      <form className="mt-6 space-y-2">
+        <input type="text" placeholder="Name" className="w-full p-2 text-black" />
+        <input type="email" placeholder="Email" className="w-full p-2 text-black" />
+        <textarea placeholder="Message" className="w-full p-2 text-black" />
+        <button className="px-4 py-2 bg-gold text-black rounded">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/jetelite/tailwind.config.js
+++ b/jetelite/tailwind.config.js
@@ -1,0 +1,14 @@
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,jsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        gold: '#d4af37'
+      }
+    },
+  },
+  plugins: [],
+}

--- a/jetelite/vite.config.js
+++ b/jetelite/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    open: true,
+  },
+});


### PR DESCRIPTION
## Summary
- initialize JetElite React project with Vite/Tailwind configuration
- add reusable components (Navbar, Footer, JetCard, WizardSteps)
- create pages for Home, Fleet, Jet details, Booking wizard, Add-ons, About, Support, Dashboard, Blog and authentication
- include sample jet data

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de71d1f988331b6c6fe3bc37bf682